### PR TITLE
Use NotImplementedError in Domain abstract methods

### DIFF
--- a/jaxdem/domain.py
+++ b/jaxdem/domain.py
@@ -92,7 +92,7 @@ class Domain(Factory["Domain"], ABC):
         Example
         -------
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     @staticmethod
     @abstractmethod
@@ -125,7 +125,7 @@ class Domain(Factory["Domain"], ABC):
         Example
         -------
         """
-        raise NotImplemented
+        raise NotImplementedError
 
 
 @Domain.register("free")


### PR DESCRIPTION
## Summary
- replace `raise NotImplemented` with `raise NotImplementedError` in `Domain.displacement`
- do the same in `Domain.shift`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cbdef1a948324a6442b44510de97e