### PR TITLE
docs: clarify grid initialization comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import jaxdem as jdem
 from jaxdem.utils import grid_state
 import jax.numpy as jnp
 
-state = grid_state(n_per_axis=(10, 10, 10), spacing=0.5, radius=0.1) # Initialize particles aranged in a grid
+state = grid_state(n_per_axis=(10, 10, 10), spacing=0.5, radius=0.1) # Initialize particles arranged in a grid
 system = jdem.System.create(state.dim, domain_type="reflect", domain_kw={"box_size": 20.0 * jnp.ones(state.dim)})
 writer = jdem.VTKWriter()
 steps = 1000


### PR DESCRIPTION
## Summary
- fix typo in README example comment about particle grid initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689cbddffd188324aae13d5a40688c4b