### PR TITLE
Improve docstring clarity and spelling

### DIFF
--- a/docs/source/contribution_guide/formatting.md
+++ b/docs/source/contribution_guide/formatting.md
@@ -1,6 +1,6 @@
-# Formating
+# Formatting
 
-We adopt an automatic formating tool to maintain the look of the codebase and avoid fights about styling and formatting.
+We adopt an automatic formatting tool to maintain the look of the codebase and avoid fights about styling and formatting.
 
 ## Black
 

--- a/docs/source/contribution_guide/index.rst
+++ b/docs/source/contribution_guide/index.rst
@@ -5,5 +5,5 @@ Contribution Guide
    :maxdepth: 2
 
    naming_conventions
-   formating
+   formatting
    documentation

--- a/examples/state_guide.py
+++ b/examples/state_guide.py
@@ -260,7 +260,7 @@ print(f"Shape of stacked positions (T, B, N, dim): {batched_state.pos.shape}")
 print(f"Batch size: {batched_state.batch_size}")
 
 # %%
-# Following the example of the previos section. You might encounter a trajectory of batches in the following way:
+# Following the example of the previous section, you might encounter a trajectory of batches in the following way:
 
 N_batches = 9
 state, system = jax.vmap(initialize)(jnp.arange(N_batches))

--- a/jaxdem/colliders/naive.py
+++ b/jaxdem/colliders/naive.py
@@ -27,7 +27,7 @@ class NaiveSimulator(Collider):
     -----
     Due to its :math:`O(N^2)` complexity, `NaiveSimulator` is suitable for simulations
     with a relatively small number of particles. For larger systems, a more
-    efficient spatial partitioning collider should be used. However, thhis collider should be the fastest
+    efficient spatial partitioning collider should be used. However, this collider should be the fastest
     option for small systems (:math:`<1k-5k` spheres depending on the GPU).
     """
 
@@ -35,10 +35,10 @@ class NaiveSimulator(Collider):
     @jax.jit
     def compute_potential_energy(state: "State", system: "System") -> jax.Array:
         r"""
-        Computes the total force on each particle using a naive :math:`O(N^2)` all-pairs loop.
+        Computes the potential energy associated with each particle using a naive :math:`O(N^2)` all-pairs loop.
 
-        This method iterates over all particle pairs (i, j) and sums the forces
-        computed by the `system.force_model`.
+        This method iterates over all particle pairs (i, j) and sums the potential energy
+        contributions computed by the ``system.force_model``.
 
         Parameters
         ----------
@@ -49,9 +49,8 @@ class NaiveSimulator(Collider):
 
         Returns
         -------
-        Tuple[State, System]
-            A tuple containing the updated `State` object with computed accelerations
-            and the `System` object.
+        jax.Array
+            One-dimensional array containing the total potential energy contribution for each particle.
 
         """
         rng = jax.lax.iota(dtype=int, size=state.N)
@@ -66,10 +65,10 @@ class NaiveSimulator(Collider):
     @jax.jit
     def compute_force(state: "State", system: "System") -> Tuple["State", "System"]:
         r"""
-        Computes the total potential energy of the system using a naive :math:`O(N^2)` all-pairs loop.
+        Computes the total force acting on each particle using a naive :math:`O(N^2)` all-pairs loop.
 
-        This method sums the potential energy contributions from all particle pairs (i, j)
-        as computed by the `system.force_model`.
+        This method sums the force contributions from all particle pairs (i, j)
+        as computed by the ``system.force_model`` and updates the particle accelerations.
 
         Parameters
         ----------
@@ -80,8 +79,9 @@ class NaiveSimulator(Collider):
 
         Returns
         -------
-        jax.Array
-            A scalar JAX array representing the total potential energy of the system.
+        Tuple[State, System]
+            A tuple containing the updated ``State`` object with computed accelerations
+            and the unmodified ``System`` object.
         """
         rng = jax.lax.iota(dtype=int, size=state.N)
         accel = state.accel + (

--- a/jaxdem/rl/actionSpaces/__init__.py
+++ b/jaxdem/rl/actionSpaces/__init__.py
@@ -24,7 +24,7 @@ class ActionSpace(Factory):
 
     Example
     -------
-    To define a custom acction space, inherit from :class:`distrax.Bijector` and :class:`ActionSpace` and implement its abstract methods:
+    To define a custom action space, inherit from :class:`distrax.Bijector` and :class:`ActionSpace` and implement its abstract methods:
 
     >>> @ActionSpace.register("myCustomActionSpace")
     >>> class MyCustomActionSpace(distrax.Bijector, ActionSpace):

--- a/jaxdem/rl/environments/__init__.py
+++ b/jaxdem/rl/environments/__init__.py
@@ -22,65 +22,68 @@ if TYPE_CHECKING:  # pragma: no cover
 @dataclass(slots=True, frozen=True)
 class Environment(Factory, ABC):
     """
-    Defines the interface for environments.
+    Defines the interface for reinforcement-learning environments.
 
-    - Let **A** = number of agents (A ≥ 1). **Single-agent envs must still use A=1.**
-    - Observations and actions are **flattened per agent** to fixed sizes.
-    and ``action_space_shape`` to reshape if needed.
+    - Let **A** be the number of agents (A ≥ 1). Single-agent environments still use A=1.
+    - Observations and actions are flattened per agent to fixed sizes. Use ``action_space_shape``
+      to reshape inside the environment if needed.
 
     **Required shapes**
+
     - Observation: ``(A, observation_space_size)``
     - Action (input to :meth:`step`): ``(A, action_space_size)``
     - Reward: ``(A,)``
-    - Done: scalar boolean for the **whole environment**
+    - Done: scalar boolean for the whole environment
 
-    TO DO: truncated data field: per agent termination flag
-    TO DO: render method
+    TODO:
+
+    - Truncated data field: per-agent termination flag
+    - Render method
 
     Example
     -------
-    To define a custom integrator, inherit from :class:`Integrator` and implement its abstract methods:
+    To define a custom environment, inherit from :class:`Environment` and implement the abstract methods:
 
-    >>> @Integrator.register("myCustomIntegrator")
+    >>> @Environment.register("MyCustomEnv")
     >>> @jax.tree_util.register_dataclass
     >>> @dataclass(slots=True, frozen=True)
-    >>> class MyCustomIntegrator(Integrator):
+    >>> class MyCustomEnv(Environment):
         ...
     """
 
     state: "State"
     """
-    Simulation state
+    Simulation state.
     """
 
     system: "System"
     """
-    Simulation system's configuration
+    Simulation system configuration.
     """
 
     env_params: Dict[str, Any]
     """
-    Environment specific parameters
+    Environment-specific parameters.
     """
 
     max_num_agents: int = field(default=0, metadata={"static": True})
     """
-    Maximun number of active agents in the environment
+    Maximum number of active agents in the environment.
     """
 
     action_space_size: int = field(default=0, metadata={"static": True})
     """
-    Flattened action size per agent: actions passed to :meth:`step` are shape ``(A, action_space_size)``.
+    Flattened action size per agent. Actions passed to :meth:`step` have shape ``(A, action_space_size)``.
     """
 
     action_space_shape: Tuple[int, ...] = field(default=(), metadata={"static": True})
     """
-    Original per-agent action shape (useful for reshaping inside the env).
+    Original per-agent action shape (useful for reshaping inside the environment).
     """
 
     observation_space_size: int = field(default=0, metadata={"static": True})
     """
-    Flattened observation size per agent: :meth:`observation` returns shape ``(A, observation_space_size)
+    Flattened observation size per agent. :meth:`observation` returns shape ``(A, observation_space_size)``.
     """
 
     _base_env_cls: ClassVar[Type["Environment"]]
@@ -98,12 +101,12 @@ class Environment(Factory, ABC):
             Instance of the environment.
 
         key : jax.random.PRNGKey
-            Jax random numbers key
+            JAX random number generator key.
 
         Returns
         -------
-        Tuple[Environment, ArrayLike]
-            Freshly initialized environment and new random numbers key.
+        Environment
+            Freshly initialized environment.
         """
         raise NotImplementedError
 
@@ -156,13 +159,13 @@ class Environment(Factory, ABC):
         env : Environment
             The current environment.
 
-        action : System
-            The vector of actions each agent on the environment should take.
+        action : jax.Array
+            The vector of actions each agent in the environment should take.
 
         Returns
         -------
         Environment
-            The updated envitonment state.
+            The updated environment state.
         """
         raise NotImplementedError
 
@@ -171,7 +174,7 @@ class Environment(Factory, ABC):
     @jax.jit
     def observation(env: "Environment") -> jax.Array:
         """
-        Return the **per-agent** observation vector.
+        Returns the per-agent observation vector.
 
         Parameters
         ----------
@@ -190,7 +193,7 @@ class Environment(Factory, ABC):
     @jax.jit
     def reward(env: "Environment") -> jax.Array:
         """
-        Return the **per-agent** immediate rewards.
+        Returns the per-agent immediate rewards.
 
         Parameters
         ----------
@@ -209,7 +212,7 @@ class Environment(Factory, ABC):
     @jax.jit
     def done(env: "Environment") -> jax.Array:
         """
-        Return a bool indicating when the environment ended.
+        Returns a boolean indicating whether the environment has ended.
 
         Parameters
         ----------
@@ -240,7 +243,7 @@ class Environment(Factory, ABC):
         Returns
         -------
         Dict
-            A dictionary with aditional information of the environment.
+            A dictionary with additional information about the environment.
         """
         return dict()
 

--- a/jaxdem/rl/models/LSTM.py
+++ b/jaxdem/rl/models/LSTM.py
@@ -193,7 +193,7 @@ class LSTMActorCritic(Model, nnx.Module):
             self.c.value = zeros
             return
 
-        # If shape matches and everything needs reseting
+        # If shape matches and everything needs resetting
         if mask is None:
             self.h.value *= 0.0
             self.c.value *= 0.0

--- a/jaxdem/rl/trainers/PPOtrainer.py
+++ b/jaxdem/rl/trainers/PPOtrainer.py
@@ -498,7 +498,7 @@ class PPOTrainer(Trainer):
             td.advantage * ratio.clip(1.0 - ppo_clip_eps, 1.0 + ppo_clip_eps),
         ).mean()
 
-        # 5) Estimate Entropy (Entropy is not available for ditributions transformed by bijectors with non-constant Jacobian determinant)
+        # 5) Estimate Entropy (Entropy is not available for distributions transformed by bijectors with non-constant Jacobian determinant)
         # H[π]=E_{a∼π}[−log π(a)]≈−1/K ∑_{k=1}^{K} log π(a^k)
         # entropy_loss = pi.entropy().mean()
         K = 2

--- a/jaxdem/state.py
+++ b/jaxdem/state.py
@@ -55,6 +55,7 @@ class State:
 
     >>> import jaxdem as jdem
     >>> import jax.numpy as jnp
+    >>> import jax
     >>>
     >>> positions = jnp.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
     >>> state = jdem.State.create(pos=positions)
@@ -65,9 +66,9 @@ class State:
 
     Creating a batched state:
 
-    >>> batched_state = jax.vmap(lambda _: State.create(pos=positions))(jnp.arange(10))
+    >>> batched_state = jax.vmap(lambda _: jdem.State.create(pos=positions))(jnp.arange(10))
     >>>
-    >>> print(f"Batch size: {batched_state.batch_size}") # 10
+    >>> print(f"Batch size: {batched_state.batch_size}")  # 10
     >>> print(f"Positions shape: {batched_state.pos.shape}")
     """
 
@@ -356,13 +357,14 @@ class State:
         >>> import jaxdem as jdem
         >>> import jax.numpy as jnp
         >>>
-        >>> state_a = jdem.create(pos=jnp.array([[0.,0.], [1.,1.]]), ID=jnp.array([0, 1]))
-        >>> state_b = jdem.State.create(pos=jnp.array([[2.,2.], [3.,3.]]), ID=jnp.array([0, 1]))
-        >>> merged_state = State.merge(state_a, state_b)
+        >>> state_a = jdem.State.create(pos=jnp.array([[0.0, 0.0], [1.0, 1.0]]), ID=jnp.array([0, 1]))
+        >>> state_b = jdem.State.create(pos=jnp.array([[2.0, 2.0], [3.0, 3.0]]), ID=jnp.array([0, 1]))
+        >>> merged_state = jdem.State.merge(state_a, state_b)
         >>>
-        >>> print(f"Merged state N: {merged_state.N}") # Expected: 4
-        >>> print(f"Merged state positions:\\n{merged_state.pos}")
-        >>> print(f"Merged state IDs: {merged_state.ID}") # Expected: [0, 1, 2, 3]
+        >>> print(f"Merged state N: {merged_state.N}")  # Expected: 4
+        >>> print(f"Merged state positions:\n{merged_state.pos}")
+        >>> print(f"Merged state IDs: {merged_state.ID}")  # Expected: [0, 1, 2, 3]
+
         """
         assert state1.is_valid and state2.is_valid, "One of the states is invalid"
         assert state1.dim == state2.dim, f"dim mismatch: {state1.dim} vs {state2.dim}"
@@ -446,22 +448,26 @@ class State:
         >>> import jax.numpy as jnp
         >>>
         >>> # Initial state with 4 particles
-        >>> state = jdem.State.create(jnp.zeros((4, 2)))
+        >>> state = jdem.State.create(pos=jnp.zeros((4, 2)))
         >>> print(f"Original state N: {state.N}, IDs: {state.ID}")
         >>>
         >>> # Add a single new particle
-        >>> state_with_added_particle = state.add(state,
-        ...                                       pos=jnp.array([[10., 10.]]),
-        ...                                       rad=jnp.array([0.5]),
-        ...                                       mass=jnp.array([2.0]))
+        >>> state_with_added_particle = jdem.State.add(
+        ...     state,
+        ...     pos=jnp.array([[10.0, 10.0]]),
+        ...     rad=jnp.array([0.5]),
+        ...     mass=jnp.array([2.0]),
+        ... )
         >>> print(f"New state N: {state_with_added_particle.N}, IDs: {state_with_added_particle.ID}")
         >>> print(f"New particle position: {state_with_added_particle.pos[-1]}")
-
-        Adding multiple new particles:
-
-        >>> state_multiple_added = state.add(state,
-        ...                                  pos=jnp.array([[10., 10.], [11., 11.], [12., 12.]]))
+        >>>
+        >>> # Add multiple new particles
+        >>> state_multiple_added = jdem.State.add(
+        ...     state,
+        ...     pos=jnp.array([[10.0, 10.0], [11.0, 11.0], [12.0, 12.0]]),
+        ... )
         >>> print(f"State with multiple added N: {state_multiple_added.N}, IDs: {state_multiple_added.ID}")
+
         """
         state2 = State.create(
             pos,

--- a/jaxdem/system.py
+++ b/jaxdem/system.py
@@ -88,49 +88,31 @@ class System:
     """
 
     integrator: "Integrator"
-    """
-    Instance of :class:`jaxdem.Integrator` that defines how the simulation state is advanced in time
-    """
+    """Instance of :class:`jaxdem.Integrator` that advances the simulation state in time."""
 
     collider: "Collider"
-    """
-    Instance of :class:`jaxdem.Collider` that performs contact detection and computes inter-particle forces and potential energies.
-    """
+    """Instance of :class:`jaxdem.Collider` that performs contact detection and computes inter-particle forces and potential energies."""
 
     domain: "Domain"
-    """
-    Instance of :class:`jaxdem.Domain` that defines the simulation boundaries, how displacement vectors are calculated, and how boundary conditions are applied
-    """
+    """Instance of :class:`jaxdem.Domain` that defines the simulation boundaries, displacement rules, and boundary conditions."""
 
     force_model: "ForceModel"
-    """
-    Instance of :class:`jaxdem.ForceModel` that defines the specific physical laws for inter-particle interactions.
-    """
+    """Instance of :class:`jaxdem.ForceModel` that defines the physical laws for inter-particle interactions."""
 
     mat_table: "MaterialTable"
-    """
-    Instance of :class:`jaxdem.MaterialTable` holding material properties and their effective interaction parameters for pairs of materials.
-    """
+    """Instance of :class:`jaxdem.MaterialTable` holding material properties and pairwise interaction parameters."""
 
     dt: jax.Array
-    r"""
-    The global simulation time step :math:`\Delta t`.
-    """
+    r"""The global simulation time step :math:`\Delta t`."""
 
     time: jax.Array
-    """
-    Time elapsed during the simulation.
-    """
+    """Elapsed simulation time."""
 
     dim: jax.Array
-    """
-    Dimension of the system.
-    """
+    """Spatial dimension of the system."""
 
     step_count: jax.Array = field(default_factory=lambda: jnp.asarray(0, dtype=int))
-    """
-    Counts the number of steps that have been performed.
-    """
+    """Number of integration steps that have been performed."""
 
     @staticmethod
     def create(
@@ -211,14 +193,17 @@ class System:
 
         Creating a system with a pre-defined MaterialTable:
 
-        >>> custom_material = Material.create("custom_mat", **custom_mat_kw)
-        >>> custom_mat_table = MaterialTable.from_materials([custom_material], matcher=jdem.MaterialMatchmaker.create("linear"))
+        >>> custom_mat_kw = dict(young=2.0e5, poisson=0.25)
+        >>> custom_material = jdem.Material.create("custom_mat", **custom_mat_kw)
+        >>> custom_mat_table = jdem.MaterialTable.from_materials(
+        ...     [custom_material], matcher=jdem.MaterialMatchmaker.create("linear")
+        ... )
         >>>
         >>> system_custom_mat = jdem.System.create(
-        >>>     dim=2,
-        >>>     mat_table=custom_mat_table,
-        >>>     force_model_type="spring"
-        >>> )
+        ...     dim=2,
+        ...     mat_table=custom_mat_table,
+        ...     force_model_type="spring"
+        ... )
         """
         integrator_kw = {} if integrator_kw is None else dict(integrator_kw)
         collider_kw = {} if collider_kw is None else dict(collider_kw)
@@ -339,21 +324,21 @@ class System:
         Example
         -------
         >>> import jaxdem as jdem
-        >>> import jax.numpy as jnp
         >>>
-        >>> state = jdem.utils.grid_state(n_per_axis=(1,1), spacing=1.0, radius=0.1)
-        >>> system = jdem.System.create(dim=2, dt=0.01, state=state)
+        >>> state = jdem.utils.grid_state(n_per_axis=(1, 1), spacing=1.0, radius=0.1)
+        >>> system = jdem.System.create(dim=2, dt=0.01)
         >>>
-        >>> # Rollout for 10 frames, saving every 5 steps
-        >>> final_state, final_system, traj = system.trajectory_rollout(
-        >>>     state, system, n=10, stride=5
-        >>> )
+        >>> # Roll out for 10 frames, saving every 5 steps
+        >>> final_state, final_system, traj = jdem.System.trajectory_rollout(
+        ...     state, system, n=10, stride=5
+        ... )
         >>>
         >>> print(f"Total simulation steps performed: {10 * 5}")
-        >>> print(f"Trajectory length (number of frames): {traj[0].pos.shape[0]}") # traj[0] is the state part of trajectory
-        >>> print(f"First frame position:\\n{traj[0].pos[0]}")
-        >>> print(f"Last frame position:\\n{traj[0].pos[-1]}")
-        >>> print(f"Final state position (should match last frame):\\n{final_state.pos}")
+        >>> print(f"Trajectory length (number of frames): {traj[0].pos.shape[0]}")  # traj[0] is the state part of the trajectory
+        >>> print(f"First frame position:\n{traj[0].pos[0]}")
+        >>> print(f"Last frame position:\n{traj[0].pos[-1]}")
+        >>> print(f"Final state position (should match last frame):\n{final_state.pos}")
+
         """
 
         @partial(jax.jit, donate_argnames=("carry"))
@@ -411,18 +396,18 @@ class System:
         Example
         -------
         >>> import jaxdem as jdem
-        >>> import jax.numpy as jnp
         >>>
-        >>> state = jdem.utils.grid_state(n_per_axis=(1,1), spacing=1.0, radius=0.1)
-        >>> system = jdem.System.create(dim=2, dt=0.01, state=state)
+        >>> state = jdem.utils.grid_state(n_per_axis=(1, 1), spacing=1.0, radius=0.1)
+        >>> system = jdem.System.create(dim=2, dt=0.01)
         >>>
         >>> # Advance by 1 step
-        >>> state_after_1_step, system_after_1_step = system.step(system.state, system)
+        >>> state_after_1_step, system_after_1_step = jdem.System.step(state, system)
         >>> print("Position after 1 step:", state_after_1_step.pos[0])
         >>>
         >>> # Advance by 10 steps
-        >>> state_after_10_steps, system_after_10_steps = system.step(system.state, system, n=10)
+        >>> state_after_10_steps, system_after_10_steps = jdem.System.step(state, system, n=10)
         >>> print("Position after 10 steps:", state_after_10_steps.pos[0])
+
         """
         body = system._steps
 

--- a/jaxdem/utils/gridState.py
+++ b/jaxdem/utils/gridState.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Part of the JaxDEM project – https://github.com/cdelv/JaxDEM
 """
-Utility functions to initialize states with particles aranged in a grid.
+Utility functions to initialize states with particles arranged in a grid.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- refine docstrings across core modules (System, State, and RL environments) to fix grammar and ensure examples use valid APIs
- correct repository-wide spelling issues and rename the formatting guide for consistent terminology
- update supporting documentation and utilities to address typos reported by codespell

## Testing
- python -m compileall jaxdem
- codespell

------
https://chatgpt.com/codex/tasks/task_e_68d477e8ec6c83248c3ca320d924d6d3