### PR TITLE
fix(colliders): restore input particle order after cell-list traversal

### DIFF
--- a/jaxdem/colliders/cell_list.py
+++ b/jaxdem/colliders/cell_list.py
@@ -268,6 +268,9 @@ def _traverse_pairs(
         return jax.tree.map(lambda x: x.sum(axis=0), cell_results)
 
     acc = jax.vmap(per_particle)(iota, p_neighbor_cell_hashes)
+    inv_perm = jnp.argsort(perm)
+    state = _reorder_state(state, inv_perm)
+    acc = jax.tree.map(lambda x: x[inv_perm], acc)
     return state, acc, hash_overflow
 
 

--- a/jaxdem/colliders/multi_cell_list.py
+++ b/jaxdem/colliders/multi_cell_list.py
@@ -254,6 +254,9 @@ def _traverse_pairs(
         return jax.tree.map(lambda x: x.sum(axis=0), cell_results)
 
     acc = jax.vmap(per_particle)(iota, p_neighbor_cell_hashes)
+    inv_perm = jnp.argsort(perm)
+    state = _reorder_state(state, inv_perm)
+    acc = jax.tree.map(lambda x: x[inv_perm], acc)
     return state, acc, hash_overflow
 
 


### PR DESCRIPTION
DynamicCellList.compute_force returned state in cell-hash sort order instead of the caller's order. Stateful callers whose buffers live outside `state` — notably FIRE in minimizers.routines, whose velocity buffer is not re-permuted — combine gradients and momentum from mismatched particles once positions (and thus the sort) change between evaluations, scrambling rigid clumps. Invert the partition permutation before returning. Same fix in multi_cell_list.